### PR TITLE
Compatibility with Oracle database

### DIFF
--- a/grails-app/domain/com/lucastex/grails/fileuploader/UFile.groovy
+++ b/grails-app/domain/com/lucastex/grails/fileuploader/UFile.groovy
@@ -17,6 +17,10 @@ class UFile {
 		dateUploaded()
 		downloads()
     }
+	
+	static mapping = {
+		size column: "`size`" /* needs to be escaped because it is a reserved word in the Oracle database */
+	}
 
 	def afterDelete() {
 		try {


### PR DESCRIPTION
Since the word `size` is a reserved word in the Oracle database it needs to be escaped by Hibernate when creating a table with this name. The solution does not fail with a "ORA-00904: string: invalid identifier" anymore.
