### PR TITLE
Changes to be compatible with Grails 2.4

### DIFF
--- a/FileUploaderGrailsPlugin.groovy
+++ b/FileUploaderGrailsPlugin.groovy
@@ -4,7 +4,7 @@ class FileUploaderGrailsPlugin {
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "1.2-M1 > *"
     // the other plugins this plugin depends on
-    def dependsOn = ["hibernate":"1.1 > *"]
+	def dependsOn = ["hibernate4":"4.3 > *"]
     // resources that are excluded from plugin packaging
     def pluginExcludes = [
     ]

--- a/application.properties
+++ b/application.properties
@@ -1,6 +1,6 @@
 #Grails Metadata file
 #Thu Jun 09 10:09:03 GFT 2011
-app.grails.version=1.3.7
+app.grails.version=2.4.4
 app.name=file-uploader
-plugins.hibernate=1.3.7
-plugins.tomcat=1.3.7
+#plugins.hibernate=1.3.7
+#plugins.tomcat=1.3.7

--- a/grails-app/controllers/com/lucastex/grails/fileuploader/FileUploaderController.groovy
+++ b/grails-app/controllers/com/lucastex/grails/fileuploader/FileUploaderController.groovy
@@ -92,7 +92,7 @@ class FileUploaderController {
     
     def show={
 			def ufile = UFile.get(params.int("id"))
-            println "aaa--------------------------------------------------------"+ufile
+            //println "aaa--------------------------------------------------------"+ufile
 	        if (!ufile) {
 	          response.sendError(404)
 	          return;

--- a/grails-app/services/com/lucastex/grails/fileuploader/FileUploaderService.groovy
+++ b/grails-app/services/com/lucastex/grails/fileuploader/FileUploaderService.groovy
@@ -1,6 +1,5 @@
 package com.lucastex.grails.fileuploader
 
-import org.codehaus.groovy.grails.commons.ConfigurationHolder
 import org.springframework.web.multipart.commons.CommonsMultipartFile
 
 class FileUploaderService {
@@ -20,7 +19,7 @@ class FileUploaderService {
   def UFile saveFile(String group, CommonsMultipartFile file, String name, Locale locale) throws FileUploaderServiceException {
 
     //config handler
-    def config = ConfigurationHolder.config.fileuploader[group]
+	def config = grails.util.Holder.config.config.fileuploader[group]
 
     /** *********************
      check extensions


### PR DESCRIPTION
Hi,
I'd like to commit few small changes in order to make plugin compatible with Grails 2.4.x:
- FileUploaderService : ConfigurationHolder is replaced by grails.util.Holder.config
- FileUploaderGrailsPlugin : dependsOn = ["hibernate4":"4.3 > *"]
- FileUploaderController : no more println (nothing to do with 2.4 but would be appreciable ;p) 
- application.properties : updated to grails 2.4.4 (and no more plugins declaration)
  Thanks, Vincent.
