### PR TITLE
Made plugin runnable for Grails Version 2.4 >

### DIFF
--- a/FileUploaderGrailsPlugin.groovy
+++ b/FileUploaderGrailsPlugin.groovy
@@ -2,7 +2,7 @@ class FileUploaderGrailsPlugin {
     // the plugin version
     def version = "1.1"
     // the version or versions of Grails the plugin is designed for
-    def grailsVersion = "1.2-M1 > *"
+    def grailsVersion = "2.4.5 > *"
     // the other plugins this plugin depends on
     def dependsOn = ["hibernate":"1.1 > *"]
     // resources that are excluded from plugin packaging

--- a/grails-app/services/com/lucastex/grails/fileuploader/FileUploaderService.groovy
+++ b/grails-app/services/com/lucastex/grails/fileuploader/FileUploaderService.groovy
@@ -1,6 +1,5 @@
 package com.lucastex.grails.fileuploader
 
-import org.codehaus.groovy.grails.commons.ConfigurationHolder
 import org.springframework.web.multipart.commons.CommonsMultipartFile
 
 class FileUploaderService {
@@ -20,7 +19,7 @@ class FileUploaderService {
   def UFile saveFile(String group, CommonsMultipartFile file, String name, Locale locale) throws FileUploaderServiceException {
 
     //config handler
-    def config = ConfigurationHolder.config.fileuploader[group]
+    def config = grails.util.Holders.config.fileuploader[group]
 
     /** *********************
      check extensions


### PR DESCRIPTION
-Allow to run in Grails version > 2.4 where Holder has been removed:
The following deprecated classes have been removed from Grails 2.4.x:
org.codehaus.groovy.grails.commons.ApplicationHolder
org.codehaus.groovy.grails.commons.ConfigurationHolder
org.codehaus.groovy.grails.plugins.PluginManagerHolder
org.codehaus.groovy.grails.web.context.ServletContextHolder
org.codehaus.groovy.grails.compiler.support.GrailsResourceLoaderHolder
http://docs.grails.org/2.4.5/guide/upgradingFrom23.html
